### PR TITLE
去除计算MA时，在遍历中遍历序号的方法 。直接传入序号，解决大数据时导致的性能问题

### DIFF
--- a/YYStockDemo/YYStockDemo/StockDataModel[数据源Model]/YYLineDataModel.h
+++ b/YYStockDemo/YYStockDemo/StockDataModel[数据源Model]/YYLineDataModel.h
@@ -15,7 +15,7 @@
  */
 @interface YYLineDataModel : NSObject <YYLineDataModelProtocol>
 
-- (void)updateMA:(NSArray *)parentDictArray;
+- (void)updateMA:(NSArray *)parentDictArray index:(NSInteger)index;
 
 
 //@property (nonatomic, assign) BOOL isShowDay;

--- a/YYStockDemo/YYStockDemo/StockDataModel[数据源Model]/YYLineDataModel.m
+++ b/YYStockDemo/YYStockDemo/StockDataModel[数据源Model]/YYLineDataModel.m
@@ -102,9 +102,9 @@
     return self;
 }
 
-- (void)updateMA:(NSArray *)parentDictArray {
+- (void)updateMA:(NSArray *)parentDictArray index:(NSInteger)index{
     _parentDictArray = parentDictArray;
-    NSInteger index = [_parentDictArray indexOfObject:_dict];
+    
     if (index >= 4) {
         NSArray *array = [_parentDictArray subarrayWithRange:NSMakeRange(index-4, 5)];
         CGFloat average = [[[array valueForKeyPath:@"close"] valueForKeyPath:@"@avg.floatValue"] floatValue];

--- a/YYStockDemo/YYStockDemo/YYStockDemoTableViewController.m
+++ b/YYStockDemo/YYStockDemo/YYStockDemoTableViewController.m
@@ -112,7 +112,7 @@
         [response[@"dayhqs"] enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
             YYLineDataModel *model = [[YYLineDataModel alloc]initWithDict:obj];
             model.preDataModel = preModel;
-            [model updateMA:response[@"dayhqs"]];
+            [model updateMA:response[@"dayhqs"] index:idx];
             NSString *day = [NSString stringWithFormat:@"%@",obj[@"day"]];
             if ([response[@"dayhqs"] count] % 18 == ([response[@"dayhqs"] indexOfObject:obj] + 1 )%18 ) {
                 model.showDay = [NSString stringWithFormat:@"%@-%@-%@",[day substringToIndex:4],[day substringWithRange:NSMakeRange(4, 2)],[day substringWithRange:NSMakeRange(6, 2)]];


### PR DESCRIPTION
去除计算MA时，在遍历中遍历序号的方法 。直接传入序号，解决大数据时导致的性能问题 。例如21*60*5条数据  就会在6300次遍历中  做一个6300的遍历。  